### PR TITLE
APPCOM-411: use hyperscience/aiocometd

### DIFF
--- a/aiosfstream/_metadata.py
+++ b/aiosfstream/_metadata.py
@@ -8,5 +8,5 @@ PROJECT_URLS = {
     "Coverage": "https://coveralls.io/github/robertmrk/aiosfstream",
     "Docs": "http://aiosfstream.readthedocs.io/"
 }
-VERSION = "0.6.0"
+VERSION = "0.5.0+hs0"
 AUTHOR = "Hyperscience"

--- a/aiosfstream/auth.py
+++ b/aiosfstream/auth.py
@@ -5,8 +5,8 @@ import reprlib
 import json
 from typing import Optional, Tuple
 
-from aiocometd_noloop import AuthExtension
-from aiocometd_noloop.typing import JsonObject, JsonLoader, JsonDumper, Payload, \
+from aiocometd import AuthExtension
+from aiocometd.typing import JsonObject, JsonLoader, JsonDumper, Payload, \
     Headers
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError

--- a/aiosfstream/client.py
+++ b/aiosfstream/client.py
@@ -8,9 +8,9 @@ from typing import Optional, Union, MutableMapping, AsyncIterator, Type, cast
 from types import TracebackType
 from enum import Enum, auto, unique
 
-from aiocometd_noloop import Client as CometdClient
-from aiocometd_noloop.exceptions import ServerError
-from aiocometd_noloop.typing import JsonObject, JsonLoader, JsonDumper
+from aiocometd import Client as CometdClient
+from aiocometd.exceptions import ServerError
+from aiocometd.typing import JsonObject, JsonLoader, JsonDumper
 
 from aiosfstream.auth import AuthenticatorBase, PasswordAuthenticator
 from aiosfstream.replay import ReplayOption, ReplayMarkerStorage, \

--- a/aiosfstream/exceptions.py
+++ b/aiosfstream/exceptions.py
@@ -18,7 +18,7 @@ import asyncio
 import contextlib
 from typing import Generator, Callable, TypeVar, Any, cast
 
-import aiocometd_noloop.exceptions as cometd_exc
+import aiocometd.exceptions as cometd_exc
 
 
 FuncType = Callable[..., Any]
@@ -102,15 +102,15 @@ EXCEPTION_PAIRS = {
 
 @contextlib.contextmanager
 def translate_errors_context() -> Generator[None, None, None]:
-    """Context manager for translating the raised aiocometd_noloop \
+    """Context manager for translating the raised aiocometd \
     errors to their aiosfstream counterparts
 
     As every properly behaving library, aiosfstream uses its own exception
-    hierarchy, just as aiocometd_noloop does. The problem is that for the users of
+    hierarchy, just as aiocometd does. The problem is that for the users of
     the library, it can be very confusing to deal with more then a single
-    exception hierarchy, so aiocometd_noloop exceptions should be tranlated to
+    exception hierarchy, so aiocometd exceptions should be tranlated to
     aiosfstream exceptions. (unfortunately we can't make aiosfstream exceptions
-    the virtual base class of aiocometd_noloop exceptions, since exception handling
+    the virtual base class of aiocometd exceptions, since exception handling
     only looks at the __mro__ to find the base class, we have no choice but to
     redefine the same exceptions)
     """
@@ -124,7 +124,7 @@ def translate_errors_context() -> Generator[None, None, None]:
 
 
 def translate_errors(func: Func) -> Func:
-    """Function decorator for translating the raised aiocometd_noloop \
+    """Function decorator for translating the raised aiocometd \
     errors to their aiosfstream counterparts
 
     :param func: Function or coroutine function

--- a/aiosfstream/replay.py
+++ b/aiosfstream/replay.py
@@ -6,9 +6,9 @@ import reprlib
 from typing import Optional, NamedTuple, MutableMapping, Any, cast, \
     AsyncContextManager
 
-from aiocometd_noloop import Extension
-from aiocometd_noloop.typing import Payload, Headers, JsonObject
-from aiocometd_noloop.constants import MetaChannel
+from aiocometd import Extension
+from aiocometd.typing import Payload, Headers, JsonObject
+from aiocometd.constants import MetaChannel
 
 from aiosfstream.exceptions import ReplayError
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 INSTALL_REQUIRES = [
-    "aiocometd-noloop==0.4.9",
+    "aiocometd==0.4.5+hs0",
     "aiohttp>=3.1,<4.0"
 ]
 TESTS_REQUIRE = [


### PR DESCRIPTION
Changed the `aiocometd` version to the custom python3.11 compatible HS version.